### PR TITLE
大佬，发现您的项目引入了io.netty:netty-common@4.1.23.Final组件，存在安全漏洞，提一个PR，建议升级修复

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.itstyle.seckill</groupId>
   <artifactId>spring-boot-seckill</artifactId>
@@ -145,7 +145,7 @@
       <dependency>
           <groupId>io.netty</groupId>
           <artifactId>netty-common</artifactId>
-          <version>4.1.23.Final</version>
+          <version>4.1.59.Final</version>
       </dependency>
       <!--beanstalkd消息队列-->
       <dependency>


### PR DESCRIPTION
本次提交修复的漏洞信息:
```
漏洞标题：Netty 安全漏洞
缺陷组件：io.netty:netty-common@4.1.23.Final
漏洞编号：CVE-2021-21290
漏洞描述：Netty是Netty社区的一款非阻塞I/O客户端-服务器框架，它主要用于开发Java网络应用程序，如协议服务器和客户端等。
Netty 4.1.59之前版本存在安全漏洞，该漏洞源于当netty的多部分解码器被使用时，如果磁盘上的临时存储被启用，则本地信息可以通过本地系统临时目录进行公开。在类unix系统中，所有用户共享临时目录。因此，使用没有显式设置文件/目录权限的api写入该目录可能导致信息泄露。值得注意的是，这并不影响现代的MacOS操作系统。法”文件。createTempFile\"在类unix系统上创建一个随机文件，但默认情况下将创建这个文件，权限为\"-rw-r——r——\"。因此，如果将敏感信息写入该文件，其他本地用户就可以读取该信息。
影响范围：[4.0.0.Final, 4.1.59.Final)
最小修复版本：4.1.59.Final
缺陷组件引入路径：com.itstyle.seckill:spring-boot-seckill@0.0.1-SNAPSHOT->io.netty:netty-common@4.1.23.Final
```
另外我运行这个项目时，IDE的安全插件提示还有132个漏洞，我不确定升级是否会有兼容性问题。您有空的话可以查看报告修复下哈。感谢感谢。

相关漏洞详细报告：https://mofeisec.com/jr?p=p99f93